### PR TITLE
業種素性を用いて株価予測を行えるようにする改修

### DIFF
--- a/src/main/java/jp/thotta/ifinance/batch/PredictorBatch.java
+++ b/src/main/java/jp/thotta/ifinance/batch/PredictorBatch.java
@@ -31,7 +31,7 @@ public class PredictorBatch {
     StockPricePredictor spp = new LinearStockPricePredictor();
     double rmse = spp.train(jsiFil);
     System.out.println("Train data size = " + jsiFil.size() + ", RMSE = " + rmse);
-    StockStatsFilter filter = new StockStatsFilter(jsiMap);
+    StockStatsFilter filter = new StockStatsFilter(jsiMap, 25, 50, 25, 25, 25);
     System.out.println(filter);
     Map<String, PredictedStockHistory> histories = 
       new HashMap<String, PredictedStockHistory>();

--- a/src/main/java/jp/thotta/ifinance/batch/PredictorBatch.java
+++ b/src/main/java/jp/thotta/ifinance/batch/PredictorBatch.java
@@ -46,6 +46,12 @@ public class PredictorBatch {
       histories.put(psh.getKeyString(), psh);
     }
     PredictedStockHistory.updateMap(histories, conn);
+    Map<String, BusinessCategoryStats> bcMap = BusinessCategoryStats.selectMap(conn);
+    System.out.println("=== 業種情報 ===");
+    for(String k : bcMap.keySet()) {
+      BusinessCategoryStats bc = bcMap.get(k);
+      System.out.println(bc);
+    }
   }
 
   public static void main(String[] args) {

--- a/src/main/java/jp/thotta/ifinance/common/StatSummary.java
+++ b/src/main/java/jp/thotta/ifinance/common/StatSummary.java
@@ -1,6 +1,7 @@
 package jp.thotta.ifinance.common;
 
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * 統計情報のサマリ.
@@ -11,6 +12,15 @@ public class StatSummary {
 
   public StatSummary(double[] d) {
     this.data = Arrays.copyOf(d, d.length);
+    Arrays.sort(this.data);
+  }
+
+  public StatSummary(List<Double> dl) {
+    this.data = new double[dl.size()];
+    int i = 0;
+    for(Double d : dl) {
+      this.data[i++] = d;
+    }
     Arrays.sort(this.data);
   }
 
@@ -28,6 +38,10 @@ public class StatSummary {
       mean += data[i] / data.length;
     }
     return mean;
+  }
+
+  public double median() {
+    return percentile(50);
   }
 
   /**

--- a/src/main/java/jp/thotta/ifinance/utilizer/BusinessCategoryStats.java
+++ b/src/main/java/jp/thotta/ifinance/utilizer/BusinessCategoryStats.java
@@ -4,6 +4,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
 import java.text.ParseException;
 
 import jp.thotta.ifinance.common.StatSummary;
@@ -16,11 +18,104 @@ import jp.thotta.ifinance.model.CompanyProfile;
  * 業種ごとの統計情報を管理.
  */
 public class BusinessCategoryStats {
-
   public String categoryName;
-  public StatSummary iPsrSummary;
-  public StatSummary iOperatingPerSummary;
-  public StatSummary iOrdinaryPerSummary;
-  public StatSummary iNetPerSummary;
-  public StatSummary iPbrSummary;
+  public Map<String, CorporatePerformance> performances;
+  public Map<String, DailyStockPrice> stockPrices;
+  public StatSummary operatingPerInverse;
+  public StatSummary ordinaryPerInverse;
+  public StatSummary netPerInverse;
+
+  public BusinessCategoryStats(String categoryName) {
+    this.categoryName = categoryName;
+    performances = new HashMap<String, CorporatePerformance>();
+    stockPrices = new HashMap<String, DailyStockPrice>();
+  }
+
+  public boolean hasEnough() {
+    return categoryName != null &&
+      performances != null &&
+      stockPrices != null &&
+      operatingPerInverse != null &&
+      ordinaryPerInverse != null &&
+      netPerInverse != null;
+  }
+
+  /**
+   * この業種の銘柄情報を追加.
+   * @param cp 決算情報
+   * @param dsp 株価情報
+   */
+  public void addItem(CorporatePerformance cp,
+      DailyStockPrice dsp) {
+    performances.put(cp.getJoinKey(), cp);
+    stockPrices.put(dsp.getJoinKey(), dsp);
+  }
+
+  /**
+   * 各種統計サマリを作成.
+   */
+  public void makeSummaries() {
+    List<Double> iOpePer = new ArrayList<Double>();
+    List<Double> iOrdPer = new ArrayList<Double>();
+    List<Double> iNetPer = new ArrayList<Double>();
+    for(String k : performances.keySet()) {
+      CorporatePerformance cp = performances.get(k);
+      DailyStockPrice dsp = stockPrices.get(k);
+      if(cp != null && dsp != null &&
+          cp.hasEnough() && dsp.hasEnough()) {
+        iOpePer.add((double)cp.operatingProfit / dsp.marketCap);
+        iOrdPer.add((double)cp.ordinaryProfit / dsp.marketCap);
+        iNetPer.add((double)cp.netProfit / dsp.marketCap);
+      }
+    }
+    operatingPerInverse = new StatSummary(iOpePer);
+    ordinaryPerInverse = new StatSummary(iOrdPer);
+    netPerInverse = new StatSummary(iNetPer);
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "categoryName: %s\n" +
+        "operatingPerInverse: %s\n" +
+        "ordinaryPerInverse: %s\n" +
+        "netPerInverse: %s\n",
+        categoryName,
+        operatingPerInverse,
+        ordinaryPerInverse,
+        netPerInverse);
+  }
+
+  /**
+   * DBから各業種の統計情報をMapで取得.
+   * @param c dbコネクション
+   * @return 業種ごとの株価指標情報のMap
+   */
+  public static Map<String, BusinessCategoryStats> selectMap(Connection c)
+    throws SQLException, ParseException {
+    Map<String, BusinessCategoryStats> m = 
+      new HashMap<String, BusinessCategoryStats>();
+    Map<String, CorporatePerformance> cpMap =
+      CorporatePerformance.selectLatests(c);
+    Map<String, DailyStockPrice> dspMap = DailyStockPrice.selectLatests(c);
+    Map<String, CompanyProfile> profMap = CompanyProfile.selectAll(c);
+    for(String k : dspMap.keySet()) {
+      DailyStockPrice dsp = dspMap.get(k);
+      CorporatePerformance cp = cpMap.get(k);
+      CompanyProfile prof = profMap.get(k);
+      if(dsp != null && cp != null && prof != null &&
+          dsp.hasEnough() && cp.hasEnough() && prof.hasEnough()) {
+        BusinessCategoryStats bc = m.get(prof.businessCategory);
+        if(bc == null) {
+          bc = new BusinessCategoryStats(prof.businessCategory);
+          m.put(prof.businessCategory, bc);
+        }
+        bc.addItem(cp, dsp);
+      }
+    }
+    for(String k : m.keySet()) {
+      m.get(k).makeSummaries();
+    }
+    return m;
+  }
 }

--- a/src/main/java/jp/thotta/ifinance/utilizer/PredictedStockPrice.java
+++ b/src/main/java/jp/thotta/ifinance/utilizer/PredictedStockPrice.java
@@ -51,15 +51,20 @@ public class PredictedStockPrice {
     return String.format(
         "%s（%4d）[%s]\n" + 
         "予想株価[%.1f円], 現在株価[%.1f円], スコア[%.1f倍]\n" +
-        "PER[%.2f倍], 配当利回り[%.2f％], 自己資本比率[%.2f％]\n" +
+        "PER[%.2f倍], 業種NetPER[%.2f倍], 配当利回り[%.2f％], 自己資本比率[%.2f％]\n" +
         //"企業情報：http://stocks.finance.yahoo.co.jp/stocks/profile/?code=%4d \n" +
         "企業特色：%s\n" +
         "決算推移：http://minkabu.jp/stock/%4d/consolidated \n" +
         "決算発表日[%s]\n",
         companyName(), stockId, businessCategory(),
         predStockPrice(), actualStockPrice(), undervaluedScore(),
-        per(), dividendYieldPercent(), ownedCapitalRatioPercent(),
+        per(), businessCategoryNetPer(),
+        dividendYieldPercent(), ownedCapitalRatioPercent(),
         companyFeature(), stockId, announceFinancialResultDate());
+  }
+
+  public double businessCategoryNetPer() {
+    return 1.0 / joinedStockInfo.businessCategoryStats.netPerInverse.median();
   }
 
   /**

--- a/src/test/java/jp/thotta/ifinance/common/StatSummaryTest.java
+++ b/src/test/java/jp/thotta/ifinance/common/StatSummaryTest.java
@@ -1,20 +1,29 @@
 package jp.thotta.ifinance.common;
 
-import junit.framework.Test;
 import junit.framework.TestCase;
-import junit.framework.TestSuite;
+
+import java.util.List;
+import java.util.ArrayList;
 
 public class StatSummaryTest extends TestCase {
   double[] d = new double[100];
+  List<Double> dList = new ArrayList<Double>();
 
   protected void setUp() {
     for(int i = 0; i < d.length; i++) {
       d[i] = 100 - i;
+      dList.add((double)(100 - i));
     }
   }
 
   public void testNormal() {
     StatSummary ss = new StatSummary(d);
+    System.out.println(ss);
+    assertEquals(ss.min(), 1, 0.01);
+    assertEquals(ss.max(), 100, 0.01);
+    assertEquals(ss.mean(), 50.5, 0.01);
+    assertEquals(ss.percentile(25), 25, 0.01);
+    ss = new StatSummary(dList);
     System.out.println(ss);
     assertEquals(ss.min(), 1, 0.01);
     assertEquals(ss.max(), 100, 0.01);

--- a/src/test/java/jp/thotta/ifinance/utilizer/BusinessCategoryStatsTest.java
+++ b/src/test/java/jp/thotta/ifinance/utilizer/BusinessCategoryStatsTest.java
@@ -1,0 +1,51 @@
+package jp.thotta.ifinance.utilizer;
+
+import junit.framework.TestCase;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ArrayList;
+
+import jp.thotta.ifinance.model.CorporatePerformance;
+import jp.thotta.ifinance.model.DailyStockPrice;
+import jp.thotta.ifinance.model.CompanyProfile;
+import jp.thotta.ifinance.model.Database;
+import jp.thotta.ifinance.common.MyDate;
+
+public class BusinessCategoryStatsTest extends TestCase {
+  Connection conn;
+  CollectorSampleGenerator csg;
+
+  protected void setUp() {
+    try {
+      csg = new CollectorSampleGenerator();
+      conn = csg.getConnection();
+    } catch(Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  public void testSelectMap() {
+    try {
+      Map<String, BusinessCategoryStats> m = BusinessCategoryStats.selectMap(conn);
+      for(String k : m.keySet()) {
+        System.out.println(m.get(k));
+      }
+    } catch(Exception e) {
+      e.printStackTrace();
+      System.exit(1);
+    }
+  }
+
+  protected void tearDown() {
+    try {
+      csg.closeConnection();
+    } catch(SQLException e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/test/java/jp/thotta/ifinance/utilizer/CollectorSampleGenerator.java
+++ b/src/test/java/jp/thotta/ifinance/utilizer/CollectorSampleGenerator.java
@@ -127,7 +127,7 @@ public class CollectorSampleGenerator {
       prof.foundationDate = new MyDate(year, month, day);
       prof.companyFeature = "aaa";
       prof.businessDescription = "aaa";
-      prof.businessCategory = "運送屋";
+      prof.businessCategory = day % 2 == 1 ? "運送屋" : "建設業";
       profMap.put(prof.getKeyString(), prof);
     }
     CompanyProfile.updateMap(profMap, conn);

--- a/src/test/java/jp/thotta/ifinance/utilizer/JoinedStockInfoTest.java
+++ b/src/test/java/jp/thotta/ifinance/utilizer/JoinedStockInfoTest.java
@@ -92,4 +92,5 @@ public class JoinedStockInfoTest extends TestCase {
       e.printStackTrace();
     }
   }
+
 }


### PR DESCRIPTION
* 業種ごとのPer値を計算し、利益×業種Perを説明変数として予測を行う
* 業種はYahoo! Financeの下記の業種を指す
http://profile.yahoo.co.jp/
